### PR TITLE
mathjs dependency error

### DIFF
--- a/src/components/BeamForm/BeamForm.tsx
+++ b/src/components/BeamForm/BeamForm.tsx
@@ -2,10 +2,20 @@ import { BeamState } from '../../types/staticAnalysis'
 import LengthForm from './LengthForm'
 import SupportsForm from './SupportsForm'
 import LoadsForm from './LoadsForm'
+import BeamAnalyzer from '../../services/beam-analyzer/BeamAnalyzer'
 
 type BeamFormProps = BeamState
 
 function BeamForm({ beam, setBeam }: BeamFormProps) {
+  function solveBeam() {
+    const { supports, loads } = beam
+    const beamAnalyzer = new BeamAnalyzer({ supports, loads })
+    const supportValues = beamAnalyzer.solveReactionForces()
+    console.log(supportValues)
+  }
+
+  // TODO: Figure out import/dependency issue causing error in console
+
   return (
     <>
       <h1>Beam information</h1>
@@ -17,6 +27,9 @@ function BeamForm({ beam, setBeam }: BeamFormProps) {
           <LoadsForm beam={beam} setBeam={setBeam} />
         </>
       )}
+      <button type="button" onClick={solveBeam}>
+        Solve beam
+      </button>
     </>
   )
 }


### PR DESCRIPTION
I get a mathjs dependency error when I try to use the BeamAnalyzer class. The tests I wrote for BeamAnalyzer work fine and also use the mathjs package. 